### PR TITLE
Fix empty optional set logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,5 @@ docs:
 	terraform-docs markdown table . > README.md
 
 test:
+	terraform -chdir=examples init
 	terraform -chdir=examples plan

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_bus_name"></a> [bus\_name](#input\_bus\_name) | Name of the bus to receive events from | `string` | n/a | yes |
 | <a name="input_event_pattern"></a> [event\_pattern](#input\_event\_pattern) | Event pattern to listen for on source bus | `string` | n/a | yes |
-| <a name="input_targets"></a> [targets](#input\_targets) | Targets to route event to, mapped by target type | <pre>object({<br>    lambda = optional(set(string))<br>    bus = optional(set(string))<br>  })</pre> | n/a | yes |
+| <a name="input_targets"></a> [targets](#input\_targets) | Targets to route event to, mapped by target type | <pre>object({<br>    lambda = optional(set(string), [])<br>    bus    = optional(set(string), [])<br>  })</pre> | n/a | yes |
 
 ## Outputs
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -20,3 +20,15 @@ module "event_mapping" {
     ]
   }
 }
+
+module "missing_one" {
+  source        = "../"
+  bus_name      = "the-knight-bus"
+  event_pattern = "event.BoggartAppear"
+
+  targets = {
+    lambda = [
+      "arn:aws:lambda:us-east-1:123456789012:function:summonPatronus"
+    ]
+  }
+}

--- a/vars.tf
+++ b/vars.tf
@@ -5,17 +5,17 @@ variable "bus_name" {
 
 variable "targets" {
   type = object({
-    lambda = optional(set(string))
-    bus    = optional(set(string))
+    lambda = optional(set(string), [])
+    bus    = optional(set(string), [])
   })
 
   validation {
-    condition     = alltrue([for arn in var.targets.lambda : (length(regexall("arn:aws:lambda:[a-z,0-9,-]+:\\d{12}:function:", arn)) > 0)])
+    condition     = alltrue([for arn in var.targets.lambda : can(regex("arn:aws:lambda:[a-z,0-9,-]+:\\d{12}:function:", arn))])
     error_message = "The lambda set may only contain lambda ARNs."
   }
 
   validation {
-    condition     = alltrue([for arn in var.targets.bus : (length(regexall("arn:aws:events:[a-z,0-9,-]+:\\d{12}:event-bus/", arn)) > 0)])
+    condition     = alltrue([for arn in var.targets.bus : can(regex("arn:aws:events:[a-z,0-9,-]+:\\d{12}:event-bus/", arn))])
     error_message = "The bus set may only contain event bus ARNs."
   }
 


### PR DESCRIPTION
An empty set, while optional, breaks the for loop logic. Provide a default empty array to ensure that failure doesn't happen.