### PR TITLE
N:N Event Mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_bus_name"></a> [bus\_name](#input\_bus\_name) | Name of the bus to receive events from | `string` | n/a | yes |
-| <a name="input_event_pattern"></a> [event\_pattern](#input\_event\_pattern) | Event pattern to listen for on source bus | `string` | n/a | yes |
+| <a name="input_event_patterns"></a> [event\_patterns](#input\_event\_patterns) | Event patterns to listen for on source bus | `list(string)` | n/a | yes |
+| <a name="input_rule_name"></a> [rule\_name](#input\_rule\_name) | Unique name to give the event rule. If empty, will use the first event pattern. | `string` | `null` | no |
 | <a name="input_targets"></a> [targets](#input\_targets) | Targets to route event to, mapped by target type | <pre>object({<br>    lambda = optional(set(string), [])<br>    bus    = optional(set(string), [])<br>  })</pre> | n/a | yes |
 
 ## Outputs

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -7,9 +7,9 @@ provider "aws" {
 }
 
 module "event_mapping" {
-  source        = "../"
-  bus_name      = "the-knight-bus"
-  event_pattern = "event.DementorsAppear"
+  source         = "../"
+  bus_name       = "the-knight-bus"
+  event_patterns = ["event.DementorsAppear"]
 
   targets = {
     bus = [
@@ -22,15 +22,31 @@ module "event_mapping" {
 }
 
 module "missing_one" {
-  source        = "../"
-  bus_name      = "the-knight-bus"
-  event_pattern = "event.BoggartAppear"
+  source         = "../"
+  bus_name       = "the-knight-bus"
+  event_patterns = ["event.BoggartAppear"]
 
   targets = {
     lambda = [
       "arn:aws:lambda:us-east-1:123456789012:function:summonPatronus",
       "arn:aws:lambda:us-east-1:123456789012:function:summonRon",
       "arn:aws:lambda:us-east-1:123456789012:function:summonHermione"
+    ]
+  }
+}
+
+module "multi_event" {
+  source   = "../"
+  bus_name = "the-knight-bus"
+  event_patterns = [
+    "event.RevokeHogsmeadePass",
+    "event.AssignDetention"
+  ]
+
+  targets = {
+    bus = [
+      "arn:aws:events:us-east-1:123456789012:event-bus/drinkButterBeer",
+      "arn:aws:events:us-east-1:123456789012:event-bus/useInvisibilityCloak"
     ]
   }
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -6,9 +6,10 @@ provider "aws" {
   region = "us-east-1"
 }
 
-module "event_mapping" {
+module "named_event_mapping" {
   source         = "../"
   bus_name       = "the-knight-bus"
+  rule_name      = "getSum"
   event_patterns = ["event.DementorsAppear"]
 
   targets = {

--- a/main.tf
+++ b/main.tf
@@ -23,11 +23,11 @@
  */
 
 resource "aws_cloudwatch_event_rule" "event_rule" {
-  name           = var.event_pattern
+  name           = local.name
   event_bus_name = var.bus_name
 
   event_pattern = jsonencode({
-    detail-type : [var.event_pattern]
+    detail-type : var.event_patterns
   })
 }
 

--- a/spec/event_mapping_spec.rb
+++ b/spec/event_mapping_spec.rb
@@ -13,45 +13,47 @@ RSpec.describe "event_mapping" do
     let(:event_rules) { @plan.resource_changes_matching(type: "aws_cloudwatch_event_rule") }
 
     it "creates aws_cloudwatch_event_rules for bus targets" do
-      expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule').twice
+      expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule').exactly(3).times
     end
 
     it "points to specified bus" do
       expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule')
-        .with_attribute_value(:event_pattern, "{\"detail-type\":[\"event.DementorsAppear\"]}")
+                         .with_attribute_value(:event_pattern, "{\"detail-type\":[\"event.DementorsAppear\"]}")
     end
 
     context "bus rules" do
-      let(:event_rule) { event_rules.first.change.after }
-
       it "configures the rule" do
-        expect(event_rule[:name]).to eq("event.DementorsAppear")
-        expect(event_rule[:event_pattern]).to eq({"detail-type": ["event.DementorsAppear"]}.to_json)
-        expect(event_rule[:event_bus_name]).to eq("the-knight-bus")
+        expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule')
+                           .with_attribute_value(:name, "event.DementorsAppear")
+                           .with_attribute_value(:event_pattern, { "detail-type": ["event.DementorsAppear"] }.to_json)
+                           .with_attribute_value(:event_bus_name, "the-knight-bus")
       end
     end
 
     context "multiple lambda targets" do
-      let(:permissions) { @plan.resource_changes_matching(type: "aws_lambda_permission") }
-      let(:permission) { permissions[1].change.after }
+      it "creates permissions for each lambda" do
+        expect(@plan).to include_resource_creation(type: 'aws_lambda_permission').exactly(4).times
+      end
 
       it "sets permissions for each target lambda" do
-        expect(permissions.count).to eq(4)
-        expect(permission[:action]).to eq("lambda:InvokeFunction")
-        expect(permission[:function_name]).to eq("summonHermione")
-        expect(permission[:principal]).to eq("events.amazonaws.com")
+        expect(@plan).to include_resource_creation(type: 'aws_lambda_permission')
+                           .with_attribute_value(:action, "lambda:InvokeFunction")
+                           .with_attribute_value(:function_name, "summonHermione")
+                           .with_attribute_value(:principal, "events.amazonaws.com")
       end
     end
 
     context "event targets" do
-      let(:targets) { @plan.resource_changes_matching(type: "aws_cloudwatch_event_target") }
-      let(:target) { targets.first.change.after }
+      it "creates targets for each lambda target" do
+        expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_target')
+                           .exactly(7).times
+      end
 
       it "sets permissions for each target lambda" do
-        expect(targets.count).to eq(5)
-        expect(target[:arn]).to eq("arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic")
-        expect(target[:rule]).to eq("event.DementorsAppear")
-        expect(target[:event_bus_name]).to eq("the-knight-bus")
+        expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_target')
+                           .with_attribute_value(:arn, "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic")
+                           .with_attribute_value(:rule, "event.DementorsAppear")
+                           .with_attribute_value(:event_bus_name, "the-knight-bus")
       end
     end
   end

--- a/spec/event_mapping_spec.rb
+++ b/spec/event_mapping_spec.rb
@@ -9,52 +9,61 @@ RSpec.describe "event_mapping" do
     expect(@plan).to be_a(RubyTerraform::Models::Plan)
   end
 
-  context "resource creation" do
-    let(:event_rules) { @plan.resource_changes_matching(type: "aws_cloudwatch_event_rule") }
-
-    it "creates aws_cloudwatch_event_rules for bus targets" do
+  context "aws_cloudwatch_event_rules" do
+    it "creates for bus targets" do
       expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule').exactly(3).times
     end
 
-    it "points to specified bus" do
+    it "points to specified bus ane names explicitly" do
       expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule')
                          .with_attribute_value(:event_pattern, "{\"detail-type\":[\"event.DementorsAppear\"]}")
+                         .with_attribute_value(:name, "getSum")
     end
 
-    context "bus rules" do
-      it "configures the rule" do
-        expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule')
-                           .with_attribute_value(:name, "event.DementorsAppear")
-                           .with_attribute_value(:event_pattern, { "detail-type": ["event.DementorsAppear"] }.to_json)
-                           .with_attribute_value(:event_bus_name, "the-knight-bus")
-      end
+    it "name defaults to first rule" do
+      expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule')
+                         .with_attribute_value(:name, "event.RevokeHogsmeadePass")
+
+      expect(@plan).not_to include_resource_creation(type: 'aws_cloudwatch_event_rule')
+                             .with_attribute_value(:name, "event.AssignDetention")
+    end
+  end
+
+  context "bus rules" do
+    it "configures the rule" do
+      expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule')
+                         .with_attribute_value(:name, "event.RevokeHogsmeadePass")
+                         .with_attribute_value(:event_pattern, {
+                           "detail-type": ["event.RevokeHogsmeadePass", "event.AssignDetention"]
+                         }.to_json)
+                         .with_attribute_value(:event_bus_name, "the-knight-bus")
+    end
+  end
+
+  context "aws_lambda_permission" do
+    it "creates permissions for each lambda" do
+      expect(@plan).to include_resource_creation(type: 'aws_lambda_permission').exactly(4).times
     end
 
-    context "multiple lambda targets" do
-      it "creates permissions for each lambda" do
-        expect(@plan).to include_resource_creation(type: 'aws_lambda_permission').exactly(4).times
-      end
+    it "sets permissions for each target lambda" do
+      expect(@plan).to include_resource_creation(type: 'aws_lambda_permission')
+                         .with_attribute_value(:action, "lambda:InvokeFunction")
+                         .with_attribute_value(:function_name, "summonHermione")
+                         .with_attribute_value(:principal, "events.amazonaws.com")
+    end
+  end
 
-      it "sets permissions for each target lambda" do
-        expect(@plan).to include_resource_creation(type: 'aws_lambda_permission')
-                           .with_attribute_value(:action, "lambda:InvokeFunction")
-                           .with_attribute_value(:function_name, "summonHermione")
-                           .with_attribute_value(:principal, "events.amazonaws.com")
-      end
+  context "aws_cloudwatch_event_target" do
+    it "creates targets for each lambda target" do
+      expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_target')
+                         .exactly(7).times
     end
 
-    context "event targets" do
-      it "creates targets for each lambda target" do
-        expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_target')
-                           .exactly(7).times
-      end
-
-      it "sets permissions for each target lambda" do
-        expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_target')
-                           .with_attribute_value(:arn, "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic")
-                           .with_attribute_value(:rule, "event.DementorsAppear")
-                           .with_attribute_value(:event_bus_name, "the-knight-bus")
-      end
+    it "sets permissions for each target lambda" do
+      expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_target')
+                         .with_attribute_value(:arn, "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic")
+                         .with_attribute_value(:rule, "getSum")
+                         .with_attribute_value(:event_bus_name, "the-knight-bus")
     end
   end
 end

--- a/vars.tf
+++ b/vars.tf
@@ -3,6 +3,12 @@ variable "bus_name" {
   description = "Name of the bus to receive events from"
 }
 
+variable "rule_name" {
+  type        = string
+  description = "Unique name to give the event rule. If empty, will use the first event pattern."
+  default     = null
+}
+
 variable "targets" {
   type = object({
     lambda = optional(set(string), [])
@@ -22,11 +28,12 @@ variable "targets" {
   description = "Targets to route event to, mapped by target type"
 }
 
-variable "event_pattern" {
-  type        = string
-  description = "Event pattern to listen for on source bus"
+variable "event_patterns" {
+  type        = list(string)
+  description = "Event patterns to listen for on source bus"
 }
 
 locals {
   lambda_names = toset([for arn in var.targets.lambda : reverse(split(":", arn))[0]])
+  name         = var.rule_name == null ? var.event_patterns[0] : var.rule_name
 }


### PR DESCRIPTION
### Are there any dependencies (software or human) that need to be addressed before this PR is merged?

🚨 Merge #7 first, pls 🚨

⚠️ Be careful with any non-explicitly version dependence on this. This is a breaking change and needs to be versioned x.Y.z version bump.

### What ticket(s) or other PRs does this relate to?

https://3.basecamp.com/5006882/buckets/29772784/card_tables/cards/5763795819

### What was the problem or feature?
It would sure be nice to be able to subscribe one or many targets to one or many events.

### What was the solution?
Allow event subscriptions to be N instead of 1.

- [x] Security Impact has been considered (if yes please describe)
- [x] Network Impacts have been considered (if yes please describe)



### Where does this work fall on the Good - Fast spectrum?
As good as it gets

### Any additional work needed as a result of merging this PR (deploy steps, other PRs, etc.)?

1. Tag and release as 0.4.0
2. Bump any version of the provider required from 0.3.x -> 0.4.0.
3. Change any `event_pattern = <string>` inputs to `event_patterns = [<string>, ...]`
4. Submit requisite PRs in those repos.

