### PR TITLE
Added filtering capabilities

### DIFF
--- a/examples/mixed_targets/main.tf
+++ b/examples/mixed_targets/main.tf
@@ -6,9 +6,10 @@ provider "aws" {
   region = "us-east-1"
 }
 
-module "multi_target" {
-  source         = "../../"
-  bus_name       = "the-knight-bus"
+module "multi-target" {
+  source   = "../../"
+  bus_name = "the-knight-bus"
+
   event_patterns = ["event.DementorsAppear"]
 
   targets = {
@@ -18,6 +19,29 @@ module "multi_target" {
     lambda = [
       "arn:aws:lambda:us-east-1:123456789012:function:summonPatronus",
       "arn:aws:lambda:us-east-1:123456789012:function:blackOut"
+    ]
+  }
+}
+
+module "added-filters" {
+  source   = "../../"
+  bus_name = "the-knight-bus"
+
+  event_patterns = ["event.SpellCast"]
+
+  filters = {
+    type  = ["curse"],
+    class = ["unforgivable"]
+  }
+
+  targets = {
+    bus = [
+      "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic"
+    ],
+    lambda = [
+      "arn:aws:lambda:us-east-1:123456789012:function:Duck",
+      "arn:aws:lambda:us-east-1:123456789012:function:Dodge",
+      "arn:aws:lambda:us-east-1:123456789012:function:Weave",
     ]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -26,9 +26,9 @@ resource "aws_cloudwatch_event_rule" "event_rule" {
   name           = local.name
   event_bus_name = var.bus_name
 
-  event_pattern = jsonencode({
+  event_pattern = jsonencode(merge({
     detail-type : var.event_patterns
-  })
+  }, local.filters))
 }
 
 # handles the target mapping for lambdas and buses (event_api is more complex)

--- a/vars.tf
+++ b/vars.tf
@@ -40,7 +40,14 @@ variable "event_patterns" {
   description = "Event patterns to listen for on source bus"
 }
 
+variable "filters" {
+  type        = map(list(string))
+  description = "Filters to apply against the event `detail`s. Must be a valid content filter (see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html)"
+  default     = null
+}
+
 locals {
   lambda_names = toset([for arn in var.targets.lambda : reverse(split(":", arn))[0]])
   name         = var.rule_name == null ? var.event_patterns[0] : var.rule_name
+  filters      = var.filters == null ? {} : { detail = var.filters }
 }


### PR DESCRIPTION
### Are there any dependencies (software or human) that need to be addressed before this PR is merged?

🚨Requires updates from #9 🚨 

### What ticket(s) or other PRs does this relate to?

https://3.basecamp.com/5006882/buckets/29772784/card_tables/cards/5763795819

### What was the problem or feature?

We want the ability to grant additional filters based on the `detail` payload.

### What was the solution?

Add an additional `filters` param which takes [valid AWS event filters](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html) and adds them to the rule's filter if present. 

Should not disrupt any use of this plugin on the 0.4.x release where additional filters are not provided.

- [x] Security Impact has been considered (if yes please describe)
- [x] Network Impacts have been considered (if yes please describe)

### Where does this work fall on the Good - Fast spectrum?


### Any additional work needed as a result of merging this PR (deploy steps, other PRs, etc.)?
