### PR TITLE
0.5.x: Resolve for_each dependency blindness

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_bus_name"></a> [bus\_name](#input\_bus\_name) | Name of the bus to receive events from | `string` | n/a | yes |
 | <a name="input_event_patterns"></a> [event\_patterns](#input\_event\_patterns) | Event patterns to listen for on source bus | `list(string)` | n/a | yes |
+| <a name="input_filters"></a> [filters](#input\_filters) | Filters to apply against the event `detail`s. Must be a valid content filter (see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html) | `map(list(string))` | `null` | no |
 | <a name="input_rule_name"></a> [rule\_name](#input\_rule\_name) | Unique name to give the event rule. If empty, will use the first event pattern. | `string` | `null` | no |
-| <a name="input_targets"></a> [targets](#input\_targets) | Targets to route event to, mapped by target type | <pre>object({<br>    lambda = optional(set(string), [])<br>    bus    = optional(set(string), [])<br>    event_api = optional(list(object({<br>      name : string,<br>      endpoint : string,<br>      token : string,<br>      template_vars = optional(map(string), {}),<br>      template      = string,<br>    })), [])<br>  })</pre> | n/a | yes |
+| <a name="input_targets"></a> [targets](#input\_targets) | Targets to route event to, mapped by target type | <pre>object({<br>    lambda = optional(map(string), {})<br>    bus    = optional(map(string), {})<br>    event_api = optional(map(object({<br>      endpoint : string,<br>      token : string,<br>      template_vars = optional(map(string), {}),<br>      template      = string,<br>    })), {})<br>  })</pre> | n/a | yes |
 
 ## Outputs
 

--- a/examples/bus_targets/main.tf
+++ b/examples/bus_targets/main.tf
@@ -15,8 +15,8 @@ module "named_event_mapping" {
   ]
 
   targets = {
-    bus = [
-      "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic"
-    ]
+    bus = {
+      MofO : "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic"
+    }
   }
 }

--- a/examples/event_api_targets/main.tf
+++ b/examples/event_api_targets/main.tf
@@ -20,9 +20,8 @@ module "named_event_mapping" {
   ]
 
   targets = {
-    event_api = [
-      {
-        name : "slack"
+    event_api = {
+      slack : {
         endpoint : "https://hooks.slack.com/services/my/random/key"
         token : "xoxb-rando-tokenizer"
 
@@ -32,8 +31,7 @@ module "named_event_mapping" {
         }
 
       },
-      {
-        name : "slack-2"
+      slack-2 : {
         endpoint : "https://hooks.slack.com/services/my/random/key"
         token : "xoxb-rando-tokenizer"
         template = <<EOF
@@ -43,6 +41,6 @@ module "named_event_mapping" {
 EOF
       }
 
-    ]
+    }
   }
 }

--- a/examples/lambda_targets/main.tf
+++ b/examples/lambda_targets/main.tf
@@ -12,10 +12,10 @@ module "lambda_targets" {
   event_patterns = ["event.MalfoyAttacks"]
 
   targets = {
-    lambda = [
-      "arn:aws:lambda:us-east-1:123456789012:function:summonRon",
-      "arn:aws:lambda:us-east-1:123456789012:function:summonHermione"
-    ]
+    lambda = {
+      ronWeasley : "arn:aws:lambda:us-east-1:123456789012:function:summonRon",
+      hermioneGranger : "arn:aws:lambda:us-east-1:123456789012:function:summonHermione"
+    }
   }
 }
 
@@ -29,8 +29,8 @@ module "multi_events" {
   ]
 
   targets = {
-    lambda = [
-      "arn:aws:lambda:us-east-1:123456789012:function:summonPatronus"
-    ]
+    lambda = {
+      patronus : "arn:aws:lambda:us-east-1:123456789012:function:summonPatronus"
+    }
   }
 }

--- a/examples/mixed_targets/main.tf
+++ b/examples/mixed_targets/main.tf
@@ -13,13 +13,13 @@ module "multi-target" {
   event_patterns = ["event.DementorsAppear"]
 
   targets = {
-    bus = [
-      "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic"
-    ],
-    lambda = [
-      "arn:aws:lambda:us-east-1:123456789012:function:summonPatronus",
-      "arn:aws:lambda:us-east-1:123456789012:function:blackOut"
-    ]
+    bus = {
+      MinOfMag : "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic"
+    },
+    lambda = {
+      summonPatronus : "arn:aws:lambda:us-east-1:123456789012:function:summonPatronus",
+      blackOut : "arn:aws:lambda:us-east-1:123456789012:function:blackOut"
+    }
   }
 }
 
@@ -35,13 +35,13 @@ module "added-filters" {
   }
 
   targets = {
-    bus = [
-      "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic"
-    ],
-    lambda = [
-      "arn:aws:lambda:us-east-1:123456789012:function:Duck",
-      "arn:aws:lambda:us-east-1:123456789012:function:Dodge",
-      "arn:aws:lambda:us-east-1:123456789012:function:Weave",
-    ]
+    bus = {
+      ministryOfMagic : "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic"
+    },
+    lambda = {
+      Duck : "arn:aws:lambda:us-east-1:123456789012:function:Duck",
+      Dodge : "arn:aws:lambda:us-east-1:123456789012:function:Dodge",
+      Weave : "arn:aws:lambda:us-east-1:123456789012:function:Weave",
+    }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -33,15 +33,15 @@ resource "aws_cloudwatch_event_rule" "event_rule" {
 
 # handles the target mapping for lambdas and buses (event_api is more complex)
 resource "aws_cloudwatch_event_target" "event_target" {
-  for_each = setunion(var.targets.lambda, var.targets.bus)
+  for_each = merge(var.targets.lambda, var.targets.bus)
 
-  arn            = each.key
+  arn            = each.value
   rule           = aws_cloudwatch_event_rule.event_rule.name
   event_bus_name = var.bus_name
 }
 
 resource "aws_lambda_permission" "permission" {
-  for_each = local.lambda_names
+  for_each = var.targets.lambda
 
   action        = "lambda:InvokeFunction"
   function_name = each.key

--- a/spec/event_api_destination_spec.rb
+++ b/spec/event_api_destination_spec.rb
@@ -61,16 +61,16 @@ RSpec.describe "event api targets" do
   end
 
   context "iam permissions" do
-    it "creates an iam policy for invocation" do
+    it "creates a single iam policy for invocation" do
       expect(@plan).to include_resource_creation(type: 'aws_iam_policy')
                          .once
-                         .with_attribute_value(:name, "event.HogwartsExternal-slack")
+                         .with_attribute_value(:name, "event.HogwartsExternal")
     end
 
-    it "creates an iam role" do
+    it "creates a single iam role" do
       expect(@plan).to include_resource_creation(type: 'aws_iam_role')
                          .once
-                         .with_attribute_value(:name, "event.HogwartsExternal-slack")
+                         .with_attribute_value(:name, "event.HogwartsExternal")
     end
 
   end

--- a/spec/lambda_targets_spec.rb
+++ b/spec/lambda_targets_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "lambda targets" do
     it "specifies permissions" do
       expect(@plan).to include_resource_creation(type: 'aws_lambda_permission')
                          .with_attribute_value(:action, "lambda:InvokeFunction")
-                         .with_attribute_value(:function_name, "summonPatronus")
+                         .with_attribute_value(:function_name, "patronus")
                          .with_attribute_value(:principal, "events.amazonaws.com")
     end
   end

--- a/vars.tf
+++ b/vars.tf
@@ -11,24 +11,23 @@ variable "rule_name" {
 
 variable "targets" {
   type = object({
-    lambda = optional(set(string), [])
-    bus    = optional(set(string), [])
-    event_api = optional(list(object({
-      name : string,
+    lambda = optional(map(string), {})
+    bus    = optional(map(string), {})
+    event_api = optional(map(object({
       endpoint : string,
       token : string,
       template_vars = optional(map(string), {}),
       template      = string,
-    })), [])
+    })), {})
   })
 
   validation {
-    condition     = alltrue([for arn in var.targets.lambda : can(regex("arn:aws:lambda:[a-z,0-9,-]+:\\d{12}:function:", arn))])
+    condition     = alltrue([for name, arn in var.targets.lambda : can(regex("arn:aws:lambda:[a-z,0-9,-]+:\\d{12}:function:", arn))])
     error_message = "The lambda set may only contain lambda ARNs."
   }
 
   validation {
-    condition     = alltrue([for arn in var.targets.bus : can(regex("arn:aws:events:[a-z,0-9,-]+:\\d{12}:event-bus/", arn))])
+    condition     = alltrue([for name, arn in var.targets.bus : can(regex("arn:aws:events:[a-z,0-9,-]+:\\d{12}:event-bus/", arn))])
     error_message = "The bus set may only contain event bus ARNs."
   }
 
@@ -47,7 +46,7 @@ variable "filters" {
 }
 
 locals {
-  lambda_names = toset([for arn in var.targets.lambda : reverse(split(":", arn))[0]])
-  name         = var.rule_name == null ? var.event_patterns[0] : var.rule_name
-  filters      = var.filters == null ? {} : { detail = var.filters }
+  #  lambda_names = toset([for arn in var.targets.lambda : reverse(split(":", arn))[0]])
+  name    = var.rule_name == null ? var.event_patterns[0] : var.rule_name
+  filters = var.filters == null ? {} : { detail = var.filters }
 }


### PR DESCRIPTION
The following error gets thrown from terraform given the unknown nature of lambdas being created at the same time as the event mapping. If we use maps instead of sets, we can name our resources more explicitly _and_ avoid the for_each issue described below.

```md
The "for_each" set includes values derived from resource attributes that
cannot be determined until apply, and so Terraform cannot determine the
full set of keys that will identify the instances of this resource.

When working with unknown values in for_each, it's better to use a map
value where the keys are defined statically in your configuration and where
only the values contain apply-time results.

Alternatively, you could use the -target planning option to first apply
only the resources that the for_each value depends on, and then apply a
second time to fully converge.
```