### PR TITLE
Add a catch all option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,6 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_event_rule_arn"></a> [event\_rule\_arn](#output\_event\_rule\_arn) | n/a |

--- a/README.md
+++ b/README.md
@@ -56,11 +56,12 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_all_events"></a> [all\_events](#input\_all\_events) | Trigger on any event. Ignores `event_patterns` if specified. | `bool` | `false` | no |
 | <a name="input_bus_name"></a> [bus\_name](#input\_bus\_name) | Name of the bus to receive events from | `string` | n/a | yes |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Enable or disable the event mapping | `bool` | `true` | no |
-| <a name="input_event_patterns"></a> [event\_patterns](#input\_event\_patterns) | Event patterns to listen for on source bus | `list(string)` | n/a | yes |
+| <a name="input_event_patterns"></a> [event\_patterns](#input\_event\_patterns) | Event patterns to listen for on source bus. | `list(string)` | `[]` | no |
 | <a name="input_filters"></a> [filters](#input\_filters) | Filters to apply against the event `detail`s. Must be a valid content filter (see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html) | `map(list(string))` | `null` | no |
-| <a name="input_rule_name"></a> [rule\_name](#input\_rule\_name) | Unique name to give the event rule. If empty, will use the first event pattern. | `string` | `null` | no |
+| <a name="input_rule_name"></a> [rule\_name](#input\_rule\_name) | Unique name to give the event rule. If empty, will use the first event pattern. Required if using `all_events` | `string` | `null` | no |
 | <a name="input_targets"></a> [targets](#input\_targets) | Targets to route event to, mapped by target type | <pre>object({<br>    lambda = optional(map(string), {})<br>    bus    = optional(map(string), {})<br>    sqs    = optional(map(string), {})<br>    event_api = optional(map(object({<br>      endpoint : string,<br>      token : string,<br>      template_vars = optional(map(string), {}),<br>      template      = string,<br>    })), {})<br>  })</pre> | n/a | yes |
 
 ## Outputs

--- a/examples/mixed_targets/main.tf
+++ b/examples/mixed_targets/main.tf
@@ -62,3 +62,17 @@ module "added-filters" {
     }
   }
 }
+
+module "any-events" {
+  source   = "../../"
+  bus_name = "the-knight-bus"
+
+  rule_name  = "CatchAll"
+  all_events = true
+
+  targets = {
+    bus = {
+      ministryOfMagic : "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic"
+    }
+  }
+}

--- a/examples/mixed_targets/main.tf
+++ b/examples/mixed_targets/main.tf
@@ -20,7 +20,6 @@ module "disabled" {
   }
 }
 
-
 module "multi-target" {
   source   = "../../"
   bus_name = "the-knight-bus"

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "aws_cloudwatch_event_rule" "event_rule" {
   is_enabled     = var.enabled
 
   event_pattern = jsonencode(merge({
-    detail-type : var.event_patterns
+    detail-type : concat(var.event_patterns, local.all_pattern)
   }, local.filters))
 }
 

--- a/spec/mixed_mapping_spec.rb
+++ b/spec/mixed_mapping_spec.rb
@@ -59,4 +59,16 @@ RSpec.describe "mixed configuration tests" do
                          }.to_json)
     end
   end
+
+  context "any-events" do
+    let(:target) { "module.any-events" }
+
+    it "can capture all events" do
+      expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule', module_address: target)
+                         .once
+                         .with_attribute_value(:event_pattern, {
+                           "detail-type": [ { "prefix": "" } ]
+                         }.to_json)
+    end
+  end
 end

--- a/vars.tf
+++ b/vars.tf
@@ -5,7 +5,7 @@ variable "bus_name" {
 
 variable "rule_name" {
   type        = string
-  description = "Unique name to give the event rule. If empty, will use the first event pattern."
+  description = "Unique name to give the event rule. If empty, will use the first event pattern. Required if using `all_events`"
   default     = null
 }
 
@@ -29,12 +29,16 @@ variable "targets" {
   })
 
   validation {
-    condition     = alltrue([for name, arn in var.targets.lambda : can(regex("arn:aws:lambda:[a-z,0-9,-]+:\\d{12}:function:", arn))])
+    condition = alltrue([
+      for name, arn in var.targets.lambda : can(regex("arn:aws:lambda:[a-z,0-9,-]+:\\d{12}:function:", arn))
+    ])
     error_message = "The lambda set may only contain lambda ARNs."
   }
 
   validation {
-    condition     = alltrue([for name, arn in var.targets.bus : can(regex("arn:aws:events:[a-z,0-9,-]+:\\d{12}:event-bus/", arn))])
+    condition = alltrue([
+      for name, arn in var.targets.bus : can(regex("arn:aws:events:[a-z,0-9,-]+:\\d{12}:event-bus/", arn))
+    ])
     error_message = "The bus set may only contain event bus ARNs."
   }
 
@@ -48,7 +52,14 @@ variable "targets" {
 
 variable "event_patterns" {
   type        = list(string)
-  description = "Event patterns to listen for on source bus"
+  default     = []
+  description = "Event patterns to listen for on source bus."
+}
+
+variable "all_events" {
+  type        = bool
+  default     = false
+  description = "Trigger on any event. Ignores `event_patterns` if specified."
 }
 
 variable "filters" {
@@ -59,6 +70,7 @@ variable "filters" {
 
 locals {
   #  lambda_names = toset([for arn in var.targets.lambda : reverse(split(":", arn))[0]])
-  name    = var.rule_name == null ? var.event_patterns[0] : var.rule_name
-  filters = var.filters == null ? {} : { detail = var.filters }
+  name        = var.rule_name == null ? var.event_patterns[0] : var.rule_name
+  all_pattern = var.all_events ? [{ prefix : "" }] : []
+  filters     = var.filters == null ? {} : { detail = var.filters }
 }


### PR DESCRIPTION
This change allows a `all_events` flag to enable a rule to listen to any and all events on the event bus.