### PR TITLE
Add Account Filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_accounts"></a> [accounts](#input\_accounts) | Allowed accounts | `list(string)` | `null` | no |
 | <a name="input_all_events"></a> [all\_events](#input\_all\_events) | Trigger on any event. Ignores `event_patterns` if specified. | `bool` | `false` | no |
 | <a name="input_bus_name"></a> [bus\_name](#input\_bus\_name) | Name of the bus to receive events from | `string` | n/a | yes |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Enable or disable the event mapping | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -56,14 +56,15 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_accounts"></a> [accounts](#input\_accounts) | Allowed accounts | `list(string)` | `null` | no |
 | <a name="input_all_events"></a> [all\_events](#input\_all\_events) | Trigger on any event. Ignores `event_patterns` if specified. | `bool` | `false` | no |
+| <a name="input_allow_accounts"></a> [allow\_accounts](#input\_allow\_accounts) | Allowed accounts. Will override `ignore_accounts` if present. | `list(string)` | `[]` | no |
 | <a name="input_bus_name"></a> [bus\_name](#input\_bus\_name) | Name of the bus to receive events from | `string` | n/a | yes |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Enable or disable the event mapping | `bool` | `true` | no |
 | <a name="input_event_patterns"></a> [event\_patterns](#input\_event\_patterns) | Event patterns to listen for on source bus. | `list(string)` | `[]` | no |
 | <a name="input_filters"></a> [filters](#input\_filters) | Filters to apply against the event `detail`s. Must be a valid content filter (see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html) | `map(list(string))` | `null` | no |
+| <a name="input_ignore_accounts"></a> [ignore\_accounts](#input\_ignore\_accounts) | Ignored accounts. Will be overridden by `allow_accounts` if present. | `list(string)` | `[]` | no |
 | <a name="input_rule_name"></a> [rule\_name](#input\_rule\_name) | Unique name to give the event rule. If empty, will use the first event pattern. Required if using `all_events` | `string` | `null` | no |
-| <a name="input_targets"></a> [targets](#input\_targets) | Targets to route event to, mapped by target type | <pre>object({<br>    lambda = optional(map(string), {})<br>    bus    = optional(map(string), {})<br>    sqs    = optional(map(string), {})<br>    event_api = optional(map(object({<br>      endpoint : string,<br>      token : string,<br>      template_vars = optional(map(string), {}),<br>      template      = string,<br>    })), {})<br>  })</pre> | n/a | yes |
+| <a name="input_targets"></a> [targets](#input\_targets) | Targets to route event to, mapped by target type | <pre>object({<br>    lambda    = optional(map(string), {})<br>    bus       = optional(map(string), {})<br>    sqs       = optional(map(string), {})<br>    event_api = optional(map(object({<br>      endpoint : string,<br>      token : string,<br>      template_vars = optional(map(string), {}),<br>      template      = string,<br>    })), {})<br>  })</pre> | n/a | yes |
 
 ## Outputs
 

--- a/examples/mixed_targets/main.tf
+++ b/examples/mixed_targets/main.tf
@@ -51,6 +51,8 @@ module "added-filters" {
     class = ["unforgivable"]
   }
 
+  accounts = ["123456789012", "098765432109"]
+
   targets = {
     bus = {
       ministryOfMagic : "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic"

--- a/examples/mixed_targets/main.tf
+++ b/examples/mixed_targets/main.tf
@@ -51,7 +51,8 @@ module "added-filters" {
     class = ["unforgivable"]
   }
 
-  accounts = ["123456789012", "098765432109"]
+  allow_accounts  = ["123456789012", "098765432109"]
+  ignore_accounts = ["2828282828282", "949494949494"] # this should be overwritten by the `allow_accounts` spec as more restrictive
 
   targets = {
     bus = {
@@ -71,6 +72,22 @@ module "any-events" {
 
   rule_name  = "CatchAll"
   all_events = true
+
+  targets = {
+    bus = {
+      ministryOfMagic : "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic"
+    }
+  }
+}
+
+module "ignored-accounts" {
+  source   = "../../"
+  bus_name = "the-knight-bus"
+
+  rule_name       = "IgnoreAccounts"
+  ignore_accounts = ["2828282828282", "949494949494"]
+
+  event_patterns = ["speak:RoomOfRequirement"]
 
   targets = {
     bus = {

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ resource "aws_cloudwatch_event_rule" "event_rule" {
 
   event_pattern = jsonencode(merge({
     detail-type : concat(var.event_patterns, local.all_pattern)
-  }, local.filters))
+  }, local.filters, local.accounts))
 }
 
 # handles the target mapping for lambdas, buses, and sqs (event_api is more complex)

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ resource "aws_cloudwatch_event_rule" "event_rule" {
 
   event_pattern = jsonencode(merge({
     detail-type : concat(var.event_patterns, local.all_pattern)
-  }, local.filters, local.accounts))
+  }, local.filters, local.not_accounts, local.accounts))
 }
 
 # handles the target mapping for lambdas, buses, and sqs (event_api is more complex)

--- a/spec/mixed_mapping_spec.rb
+++ b/spec/mixed_mapping_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe "mixed configuration tests" do
       expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule', module_address: target)
                          .once
                          .with_attribute_value(:event_pattern, {
+                           "account": %w[123456789012 098765432109],
                            "detail": {
                              "class": ["unforgivable"],
                              "type": ["curse"]

--- a/spec/mixed_mapping_spec.rb
+++ b/spec/mixed_mapping_spec.rb
@@ -72,4 +72,17 @@ RSpec.describe "mixed configuration tests" do
                          }.to_json)
     end
   end
+
+  context "ignored-accounts" do
+    let(:target) { "module.ignored-accounts" }
+
+    it "can filter out accounts" do
+      expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule', module_address: target)
+                         .once
+                         .with_attribute_value(:event_pattern, {
+                           "account": { "anything-but": %w[2828282828282 949494949494] },
+                           "detail-type": [ "speak:RoomOfRequirement" ]
+                         }.to_json)
+    end
+  end
 end

--- a/vars.tf
+++ b/vars.tf
@@ -68,9 +68,16 @@ variable "filters" {
   default     = null
 }
 
+variable "accounts" {
+  type        = list(string)
+  description = "Allowed accounts"
+  default     = null
+}
+
 locals {
   #  lambda_names = toset([for arn in var.targets.lambda : reverse(split(":", arn))[0]])
   name        = var.rule_name == null ? var.event_patterns[0] : var.rule_name
   all_pattern = var.all_events ? [{ prefix : "" }] : []
   filters     = var.filters == null ? {} : { detail = var.filters }
+  accounts    = var.accounts == null ? {} : { account = var.accounts }
 }


### PR DESCRIPTION
Related: https://3.basecamp.com/5006882/buckets/31580731/card_tables/cards/6085586124

We often have need to filter our events by account IDs. This will make it possible to do so.

Adds an `allow_accounts` list var that we can specify allowed accounts.
Adds an `ignore_accounts` list var that we can exclude accounts. 

If both are specified, `allow_accounts` will override as it is the more restrictive and explicit of the two.
