### PR TITLE
Make it easier to exclude self

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ No modules.
 | [aws_iam_policy.api_event_invoke](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.api_event](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_lambda_permission.permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_caller_identity.self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.api_event_invoke](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.event_api_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
@@ -61,13 +62,15 @@ No modules.
 | <a name="input_bus_name"></a> [bus\_name](#input\_bus\_name) | Name of the bus to receive events from | `string` | n/a | yes |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Enable or disable the event mapping | `bool` | `true` | no |
 | <a name="input_event_patterns"></a> [event\_patterns](#input\_event\_patterns) | Event patterns to listen for on source bus. | `list(string)` | `[]` | no |
+| <a name="input_exclude_self"></a> [exclude\_self](#input\_exclude\_self) | Exclude the calling account's events | `bool` | `false` | no |
 | <a name="input_filters"></a> [filters](#input\_filters) | Filters to apply against the event `detail`s. Must be a valid content filter (see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html) | `map(list(string))` | `null` | no |
 | <a name="input_ignore_accounts"></a> [ignore\_accounts](#input\_ignore\_accounts) | Ignored accounts. Will be overridden by `allow_accounts` if present. | `list(string)` | `[]` | no |
 | <a name="input_rule_name"></a> [rule\_name](#input\_rule\_name) | Unique name to give the event rule. If empty, will use the first event pattern. Required if using `all_events` | `string` | `null` | no |
-| <a name="input_targets"></a> [targets](#input\_targets) | Targets to route event to, mapped by target type | <pre>object({<br>    lambda    = optional(map(string), {})<br>    bus       = optional(map(string), {})<br>    sqs       = optional(map(string), {})<br>    event_api = optional(map(object({<br>      endpoint : string,<br>      token : string,<br>      template_vars = optional(map(string), {}),<br>      template      = string,<br>    })), {})<br>  })</pre> | n/a | yes |
+| <a name="input_targets"></a> [targets](#input\_targets) | Targets to route event to, mapped by target type | <pre>object({<br>    lambda = optional(map(string), {})<br>    bus    = optional(map(string), {})<br>    sqs    = optional(map(string), {})<br>    event_api = optional(map(object({<br>      endpoint : string,<br>      token : string,<br>      template_vars = optional(map(string), {}),<br>      template      = string,<br>    })), {})<br>  })</pre> | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| <a name="output_account_id"></a> [account\_id](#output\_account\_id) | n/a |
 | <a name="output_event_rule_arn"></a> [event\_rule\_arn](#output\_event\_rule\_arn) | n/a |

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "self" {}

--- a/examples/mixed_targets/main.tf
+++ b/examples/mixed_targets/main.tf
@@ -80,12 +80,31 @@ module "any-events" {
   }
 }
 
+data "aws_caller_identity" "self" {}
+
 module "ignored-accounts" {
   source   = "../../"
   bus_name = "the-knight-bus"
 
   rule_name       = "IgnoreAccounts"
   ignore_accounts = ["2828282828282", "949494949494"]
+  exclude_self    = true
+
+  event_patterns = ["speak:RoomOfRequirement"]
+
+  targets = {
+    bus = {
+      ministryOfMagic : "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic"
+    }
+  }
+}
+
+module "ignored-self" {
+  source   = "../../"
+  bus_name = "the-knight-bus"
+
+  rule_name    = "IgnoreSelf"
+  exclude_self = true
 
   event_patterns = ["speak:RoomOfRequirement"]
 

--- a/spec/mixed_mapping_spec.rb
+++ b/spec/mixed_mapping_spec.rb
@@ -75,12 +75,27 @@ RSpec.describe "mixed configuration tests" do
 
   context "ignored-accounts" do
     let(:target) { "module.ignored-accounts" }
+    let(:current_account) { @plan.to_h.dig(:prior_state, :values, :root_module, :resources, 0, :values, :account_id) }
 
-    it "can filter out accounts" do
+    it "can filter out accounts and includes caller account when designated" do
       expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule', module_address: target)
                          .once
                          .with_attribute_value(:event_pattern, {
-                           "account": { "anything-but": %w[2828282828282 949494949494] },
+                           "account": { "anything-but": ["2828282828282", "949494949494", current_account] },
+                           "detail-type": [ "speak:RoomOfRequirement" ]
+                         }.to_json)
+    end
+  end
+
+  context "ignored-self" do
+    let(:target) { "module.ignored-self" }
+    let(:current_account) { @plan.to_h.dig(:prior_state, :values, :root_module, :resources, 0, :values, :account_id) }
+
+    it "can filter caller account only" do
+      expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule', module_address: target)
+                         .once
+                         .with_attribute_value(:event_pattern, {
+                           "account": { "anything-but": [current_account] },
                            "detail-type": [ "speak:RoomOfRequirement" ]
                          }.to_json)
     end


### PR DESCRIPTION
Add an `exclude_self` flag to exclude the caller account without having to lookup and pass explicitly

https://3.basecamp.com/5006882/buckets/31580731/card_tables/cards/6085586124