### PR TITLE
Add Step Function targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,20 @@ No modules.
 | [aws_cloudwatch_event_rule.event_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.event_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_event_target.event_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
-| [aws_iam_policy.api_event_invoke](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_role.api_event](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.event_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.api_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.bus_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.lambda_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.sfn_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.sqs_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_lambda_permission.permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_caller_identity.self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.api_event_invoke](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.event_api_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.bus_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.lambda_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.sfn_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.sqs_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
@@ -66,11 +74,10 @@ No modules.
 | <a name="input_filters"></a> [filters](#input\_filters) | Filters to apply against the event `detail`s. Must be a valid content filter (see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html) | `map(list(string))` | `null` | no |
 | <a name="input_ignore_accounts"></a> [ignore\_accounts](#input\_ignore\_accounts) | Ignored accounts. Will be overridden by `allow_accounts` if present. | `list(string)` | `[]` | no |
 | <a name="input_rule_name"></a> [rule\_name](#input\_rule\_name) | Unique name to give the event rule. If empty, will use the first event pattern. Required if using `all_events` | `string` | `null` | no |
-| <a name="input_targets"></a> [targets](#input\_targets) | Targets to route event to, mapped by target type | <pre>object({<br>    lambda = optional(map(string), {})<br>    bus    = optional(map(string), {})<br>    sqs    = optional(map(string), {})<br>    event_api = optional(map(object({<br>      endpoint : string,<br>      token : string,<br>      template_vars = optional(map(string), {}),<br>      template      = string,<br>    })), {})<br>  })</pre> | n/a | yes |
+| <a name="input_targets"></a> [targets](#input\_targets) | Targets to route event to, mapped by target type | <pre>object({<br>    lambda = optional(map(string), {})<br>    bus    = optional(map(string), {})<br>    sqs    = optional(map(string), {})<br>    sfn    = optional(map(string), {})<br>    event_api = optional(map(object({<br>      endpoint : string,<br>      token : string,<br>      template_vars = optional(map(string), {}),<br>      template      = string,<br>    })), {})<br>  })</pre> | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_account_id"></a> [account\_id](#output\_account\_id) | n/a |
 | <a name="output_event_rule_arn"></a> [event\_rule\_arn](#output\_event\_rule\_arn) | n/a |

--- a/api_destination.tf
+++ b/api_destination.tf
@@ -24,51 +24,12 @@ resource "aws_cloudwatch_event_connection" "connection" {
   }
 }
 
-data "aws_iam_policy_document" "event_api_assume_role" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["events.amazonaws.com"]
-    }
-  }
-}
-
-data "aws_iam_policy_document" "api_event_invoke" {
-  statement {
-    actions = [
-      "events:InvokeApiDestination"
-    ]
-    resources = [for k, v in aws_cloudwatch_event_api_destination.destination : v.arn]
-  }
-}
-
-resource "aws_iam_policy" "api_event_invoke" {
-  count = length(var.targets.event_api) > 0 ? 1 : 0
-
-  name   = local.name
-  policy = data.aws_iam_policy_document.api_event_invoke.json
-}
-
-resource "aws_iam_role" "api_event" {
-  count = length(var.targets.event_api) > 0 ? 1 : 0
-
-  name               = local.name
-  assume_role_policy = data.aws_iam_policy_document.event_api_assume_role.json
-
-  managed_policy_arns = [
-    aws_iam_policy.api_event_invoke[0].arn
-  ]
-}
-
 resource "aws_cloudwatch_event_target" "event_api" {
   for_each = var.targets.event_api
 
   rule           = aws_cloudwatch_event_rule.event_rule.name
   arn            = aws_cloudwatch_event_api_destination.destination[each.key].arn
-  role_arn       = aws_iam_role.api_event[0].arn
+  role_arn       = aws_iam_role.event_role.arn
   event_bus_name = var.bus_name
 
   input_transformer {

--- a/examples/step_function_targets/main.tf
+++ b/examples/step_function_targets/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 0.14.0"
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "named_event_mapping" {
+  source   = "../../"
+  bus_name = "the-knight-bus"
+
+  rule_name = "PolyjuicePotion"
+
+  event_patterns = [
+    "command.MakePolyjuicePotion"
+  ]
+
+  targets = {
+    sfn = {
+      PolyJuicer : "arn:aws:states:us-east-1:123456789012:stateMachine:PolyJuicePotion"
+    }
+  }
+}

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,91 @@
+data "aws_iam_policy_document" "assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "event_role" {
+  name               = local.name
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+}
+
+data "aws_iam_policy_document" "sfn_policy" {
+  statement {
+    actions   = ["states:StartExecution"]
+    resources = values(var.targets.sfn)
+  }
+}
+
+data "aws_iam_policy_document" "lambda_policy" {
+  statement {
+    actions   = ["lambda:InvokeFunction"]
+    resources = values(var.targets.lambda)
+  }
+}
+
+data "aws_iam_policy_document" "sqs_policy" {
+  statement {
+    actions   = ["sqs:SendMessage"]
+    resources = values(var.targets.sqs)
+  }
+}
+
+data "aws_iam_policy_document" "bus_policy" {
+  statement {
+    actions   = ["events:PutEvents"]
+    resources = values(var.targets.bus)
+  }
+}
+
+data "aws_iam_policy_document" "api_event_invoke" {
+  statement {
+    actions = [
+      "events:InvokeApiDestination"
+    ]
+    resources = [for k, v in aws_cloudwatch_event_api_destination.destination : v.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "api_events" {
+  count = length(var.targets.event_api) > 0 ? 1 : 0
+
+  name   = "invoke-api"
+  role   = aws_iam_role.event_role.id
+  policy = data.aws_iam_policy_document.api_event_invoke.json
+}
+
+resource "aws_iam_role_policy" "sqs_events" {
+  count = length(var.targets.sqs) > 0 ? 1 : 0
+
+  name   = "invoke-sqs"
+  role   = aws_iam_role.event_role.id
+  policy = data.aws_iam_policy_document.sqs_policy.json
+}
+
+resource "aws_iam_role_policy" "lambda_events" {
+  count = length(var.targets.lambda) > 0 ? 1 : 0
+
+  name   = "invoke-lambda"
+  role   = aws_iam_role.event_role.id
+  policy = data.aws_iam_policy_document.lambda_policy.json
+}
+
+resource "aws_iam_role_policy" "bus_events" {
+  count = length(var.targets.bus) > 0 ? 1 : 0
+
+  name   = "invoke-bus"
+  role   = aws_iam_role.event_role.id
+  policy = data.aws_iam_policy_document.bus_policy.json
+}
+
+resource "aws_iam_role_policy" "sfn_events" {
+  count = length(var.targets.sfn) > 0 ? 1 : 0
+
+  name   = "invoke-sfn"
+  role   = aws_iam_role.event_role.id
+  policy = data.aws_iam_policy_document.sfn_policy.json
+}

--- a/main.tf
+++ b/main.tf
@@ -34,9 +34,10 @@ resource "aws_cloudwatch_event_rule" "event_rule" {
 
 # handles the target mapping for lambdas, buses, and sqs (event_api is more complex)
 resource "aws_cloudwatch_event_target" "event_target" {
-  for_each = merge(var.targets.lambda, var.targets.bus, var.targets.sqs)
+  for_each = merge(var.targets.lambda, var.targets.bus, var.targets.sqs, var.targets.sfn)
 
   arn            = each.value
+  role_arn       = aws_iam_role.event_role.arn
   rule           = aws_cloudwatch_event_rule.event_rule.name
   event_bus_name = var.bus_name
 }

--- a/spec/event_api_destination_spec.rb
+++ b/spec/event_api_destination_spec.rb
@@ -60,19 +60,22 @@ RSpec.describe "event api targets" do
     end
   end
 
-  context "iam permissions" do
-    it "creates a single iam policy for invocation" do
-      expect(@plan).to include_resource_creation(type: 'aws_iam_policy')
-                         .once
-                         .with_attribute_value(:name, "event.HogwartsExternal")
+
+  context "aws_iam_role" do
+    it "creates iam role for target" do
+      expect(@plan).to include_resource_creation(type: 'aws_iam_role').exactly(1).times
+      expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy').exactly(1).times
     end
 
-    it "creates a single iam role" do
-      expect(@plan).to include_resource_creation(type: 'aws_iam_role')
-                         .once
-                         .with_attribute_value(:name, "event.HogwartsExternal")
-    end
+    it "permits only actions required" do
+      expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy')
+                         .with_attribute_value(:name, "invoke-api")
 
+      # can't currently validate this because the policy is generated based on the ARNs created by
+      # other resources
+      # .with_attribute_value(:policy, include("events:InvokeApiDestination"))
+
+    end
   end
 
   context "excludes" do

--- a/spec/lambda_targets_spec.rb
+++ b/spec/lambda_targets_spec.rb
@@ -51,6 +51,19 @@ RSpec.describe "lambda targets" do
     end
   end
 
+  context "aws_iam_role" do
+    it "creates iam role for target" do
+      expect(@plan).to include_resource_creation(type: 'aws_iam_role').exactly(2).times
+      expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy').exactly(2).times
+    end
+
+    it "permits only actions required" do
+      expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy')
+                         .with_attribute_value(:name, "invoke-lambda")
+                         .with_attribute_value(:policy, include("lambda:InvokeFunction"))
+    end
+  end
+
   context "aws_lambda_permission" do
     it "creates lambda permissions" do
       expect(@plan).to include_resource_creation(type: 'aws_lambda_permission').exactly(3).times

--- a/spec/mixed_mapping_spec.rb
+++ b/spec/mixed_mapping_spec.rb
@@ -38,6 +38,22 @@ RSpec.describe "mixed configuration tests" do
       expect(@plan).to include_resource_creation(type: 'aws_lambda_permission', module_address: target).exactly(2).times
     end
 
+    context "aws_iam_role" do
+      it "creates iam role for target" do
+        expect(@plan).to include_resource_creation(type: 'aws_iam_role', module_address: target).exactly(1).times
+        expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: target).exactly(3).times
+      end
+
+      it "permits only actions required" do
+        expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: target)
+                           .with_attribute_value(:name, "invoke-lambda")
+        expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: target)
+                           .with_attribute_value(:name, "invoke-bus")
+        expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: target)
+                           .with_attribute_value(:name, "invoke-sqs")
+      end
+    end
+
     # Fix this
     xit "outputs the event rule arn" do
       expect(@plan).to include_output(value: 'event_rule_arn')
@@ -58,6 +74,18 @@ RSpec.describe "mixed configuration tests" do
                            },
                            "detail-type": ["event.SpellCast"]
                          }.to_json)
+    end
+
+    it "permits resources properly" do
+      expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: target).exactly(2).times
+
+      expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: target)
+                         .with_attribute_value(:name, "invoke-lambda")
+                         .with_attribute_value(:policy, include("function:Duck", "function:Dodge", "function:Weave"))
+
+      expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: target)
+                         .with_attribute_value(:name, "invoke-bus")
+                         .with_attribute_value(:policy, include("event-bus/ministryOfMagic"))
     end
   end
 

--- a/spec/sfn_targets_spec.rb
+++ b/spec/sfn_targets_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe "step function targets" do
+  before :all do
+    @plan = plan(configuration_directory: 'examples/step_function_targets')
+  end
+
+  context "aws_cloudwatch_event_rules" do
+    it "creates for sfn targets" do
+      expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule').exactly(1).times
+    end
+
+    it "points to specified step function explicitly" do
+      expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule')
+                         .with_attribute_value(:name, "PolyjuicePotion")
+                         .with_attribute_value(:event_pattern, {"detail-type": ["command.MakePolyjuicePotion"]}.to_json)
+    end
+  end
+
+
+  context "aws_cloudwatch_event_target" do
+    it "creates for rules targets" do
+      expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_target').exactly(1).times
+    end
+
+    it "specifies targets" do
+      expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_target')
+                         .with_attribute_value(:arn, "arn:aws:states:us-east-1:123456789012:stateMachine:PolyJuicePotion")
+                         .with_attribute_value(:event_bus_name, "the-knight-bus")
+                         .with_attribute_value(:rule, "PolyjuicePotion")
+    end
+  end
+
+  context "aws_iam_role" do
+    it "creates iam role for target" do
+      expect(@plan).to include_resource_creation(type: 'aws_iam_role').exactly(1).times
+      expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy').exactly(1).times
+    end
+
+    it "permits only actions required" do
+      expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy')
+                         .with_attribute_value(:name, "invoke-sfn")
+                         .with_attribute_value(:policy, include("states:StartExecution"))
+    end
+  end
+
+  context "excludes" do
+    it "does not create lambda permissions" do
+      expect(@plan).not_to include_resource_creation(type: 'aws_lambda_permission')
+    end
+  end
+end

--- a/vars.tf
+++ b/vars.tf
@@ -26,6 +26,7 @@ variable "targets" {
     lambda = optional(map(string), {})
     bus    = optional(map(string), {})
     sqs    = optional(map(string), {})
+    sfn    = optional(map(string), {})
     event_api = optional(map(object({
       endpoint : string,
       token : string,
@@ -51,6 +52,11 @@ variable "targets" {
   validation {
     condition     = alltrue([for name, arn in var.targets.sqs : can(regex("arn:aws:sqs:[a-z,0-9,-]+:\\d{12}:", arn))])
     error_message = "The sqs set may only contain sqs queue ARNs."
+  }
+
+  validation {
+    condition     = alltrue([for name, arn in var.targets.sfn : can(regex("arn:aws:states:[a-z,0-9,-]+:\\d{12}:stateMachine:", arn))])
+    error_message = "The sfn set may only contain step function ARNs."
   }
 
   description = "Targets to route event to, mapped by target type"


### PR DESCRIPTION
This PR will allow event buses to target step functions as event triggers.

```terraform
module "sfn_event_mapping" {
  source   = "highwingio/event-mapping/aws"
  version = "0.6.3"  # forthcoming
  bus_name = "the-knight-bus"

  rule_name = "PolyjuicePotion"

  event_patterns = [
    "command.MakePolyjuicePotion"
  ]

  targets = {
    sfn = {
      PolyJuicer : "arn:aws:states:us-east-1:123456789012:stateMachine:PolyJuicePotion"    # or use the output from a resource
    }
  }
}
```

Some possible rework to map lambdas AND step functions under the same heading, but because the permission set required is different, explicit mapping keeps this simpler.

This also creates an IAM role for _any_ of the target types, attaches it to the rule, and adds the permissions necessary to trigger that target (includes SQS, Lambda, SFNs, APIs or other buses)!

Includes tests!