### PR TITLE
IAM issues + nested filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,13 @@ No modules.
 | [aws_iam_role.event_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.api_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.bus_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.lambda_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.sfn_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.sqs_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_lambda_permission.permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_caller_identity.self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.api_event_invoke](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.bus_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.lambda_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sfn_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.sqs_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
@@ -71,7 +67,7 @@ No modules.
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Enable or disable the event mapping | `bool` | `true` | no |
 | <a name="input_event_patterns"></a> [event\_patterns](#input\_event\_patterns) | Event patterns to listen for on source bus. | `list(string)` | `[]` | no |
 | <a name="input_exclude_self"></a> [exclude\_self](#input\_exclude\_self) | Exclude the calling account's events | `bool` | `false` | no |
-| <a name="input_filters"></a> [filters](#input\_filters) | Filters to apply against the event `detail`s. Must be a valid content filter (see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html) | `map(list(string))` | `null` | no |
+| <a name="input_filters"></a> [filters](#input\_filters) | Filters to apply against the event `detail`s. Must be a valid content filter (see [docs](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html)) | `map(any)` | `null` | no |
 | <a name="input_ignore_accounts"></a> [ignore\_accounts](#input\_ignore\_accounts) | Ignored accounts. Will be overridden by `allow_accounts` if present. | `list(string)` | `[]` | no |
 | <a name="input_rule_name"></a> [rule\_name](#input\_rule\_name) | Unique name to give the event rule. If empty, will use the first event pattern. Required if using `all_events` | `string` | `null` | no |
 | <a name="input_targets"></a> [targets](#input\_targets) | Targets to route event to, mapped by target type | <pre>object({<br>    lambda = optional(map(string), {})<br>    bus    = optional(map(string), {})<br>    sqs    = optional(map(string), {})<br>    sfn    = optional(map(string), {})<br>    event_api = optional(map(object({<br>      endpoint : string,<br>      token : string,<br>      template_vars = optional(map(string), {}),<br>      template      = string,<br>    })), {})<br>  })</pre> | n/a | yes |

--- a/api_destination.tf
+++ b/api_destination.tf
@@ -29,7 +29,7 @@ resource "aws_cloudwatch_event_target" "event_api" {
 
   rule           = aws_cloudwatch_event_rule.event_rule.name
   arn            = aws_cloudwatch_event_api_destination.destination[each.key].arn
-  role_arn       = aws_iam_role.event_role.arn
+  role_arn       = aws_iam_role.event_role[0].arn
   event_bus_name = var.bus_name
 
   input_transformer {

--- a/examples/mixed_targets/main.tf
+++ b/examples/mixed_targets/main.tf
@@ -114,3 +114,25 @@ module "ignored-self" {
     }
   }
 }
+
+module "nested-filters" {
+  source   = "../../"
+  bus_name = "the-knight-bus"
+
+  rule_name = "NestingFilters"
+
+  event_patterns = ["cast:spell:unforgivable"]
+  filters = {
+    punishment = {
+      level = {
+        strictest = [true]
+      }
+    }
+  }
+
+  targets = {
+    bus = {
+      ministryOfMagic : "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "aws_cloudwatch_event_target" "event_target" {
   for_each = merge(var.targets.lambda, var.targets.bus, var.targets.sqs, var.targets.sfn)
 
   arn            = each.value
-  role_arn       = aws_iam_role.event_role.arn
+  role_arn       = local.needs_iam ? aws_iam_role.event_role[0].arn : null
   rule           = aws_cloudwatch_event_rule.event_rule.name
   event_bus_name = var.bus_name
 }

--- a/spec/lambda_targets_spec.rb
+++ b/spec/lambda_targets_spec.rb
@@ -52,15 +52,9 @@ RSpec.describe "lambda targets" do
   end
 
   context "aws_iam_role" do
-    it "creates iam role for target" do
-      expect(@plan).to include_resource_creation(type: 'aws_iam_role').exactly(2).times
-      expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy').exactly(2).times
-    end
-
-    it "permits only actions required" do
-      expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy')
-                         .with_attribute_value(:name, "invoke-lambda")
-                         .with_attribute_value(:policy, include("lambda:InvokeFunction"))
+    it "does not create iam role for target" do
+      expect(@plan).to include_resource_creation(type: 'aws_iam_role').exactly(0).times
+      expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy').exactly(0).times
     end
   end
 

--- a/spec/mixed_mapping_spec.rb
+++ b/spec/mixed_mapping_spec.rb
@@ -41,16 +41,12 @@ RSpec.describe "mixed configuration tests" do
     context "aws_iam_role" do
       it "creates iam role for target" do
         expect(@plan).to include_resource_creation(type: 'aws_iam_role', module_address: target).exactly(1).times
-        expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: target).exactly(3).times
+        expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: target).exactly(1).times
       end
 
       it "permits only actions required" do
         expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: target)
-                           .with_attribute_value(:name, "invoke-lambda")
-        expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: target)
                            .with_attribute_value(:name, "invoke-bus")
-        expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: target)
-                           .with_attribute_value(:name, "invoke-sqs")
       end
     end
 
@@ -77,11 +73,7 @@ RSpec.describe "mixed configuration tests" do
     end
 
     it "permits resources properly" do
-      expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: target).exactly(2).times
-
-      expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: target)
-                         .with_attribute_value(:name, "invoke-lambda")
-                         .with_attribute_value(:policy, include("function:Duck", "function:Dodge", "function:Weave"))
+      expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: target).exactly(1).times
 
       expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: target)
                          .with_attribute_value(:name, "invoke-bus")

--- a/spec/mixed_mapping_spec.rb
+++ b/spec/mixed_mapping_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe "mixed configuration tests" do
 
     it "creates a disabled rule" do
       expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule', module_address: target)
-        .once
-        .with_attribute_value(:is_enabled, false)
+                         .once
+                         .with_attribute_value(:is_enabled, false)
     end
   end
 
@@ -96,7 +96,7 @@ RSpec.describe "mixed configuration tests" do
       expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule', module_address: target)
                          .once
                          .with_attribute_value(:event_pattern, {
-                           "detail-type": [ { "prefix": "" } ]
+                           "detail-type": [{ "prefix": "" }]
                          }.to_json)
     end
   end
@@ -110,7 +110,7 @@ RSpec.describe "mixed configuration tests" do
                          .once
                          .with_attribute_value(:event_pattern, {
                            "account": { "anything-but": ["2828282828282", "949494949494", current_account] },
-                           "detail-type": [ "speak:RoomOfRequirement" ]
+                           "detail-type": ["speak:RoomOfRequirement"]
                          }.to_json)
     end
   end
@@ -124,7 +124,26 @@ RSpec.describe "mixed configuration tests" do
                          .once
                          .with_attribute_value(:event_pattern, {
                            "account": { "anything-but": [current_account] },
-                           "detail-type": [ "speak:RoomOfRequirement" ]
+                           "detail-type": ["speak:RoomOfRequirement"]
+                         }.to_json)
+    end
+  end
+
+  context "nested-filters" do
+    let(:target) { "module.nested-filters" }
+
+    it "can build nested filters " do
+      expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule', module_address: target)
+                         .once
+                         .with_attribute_value(:event_pattern, {
+                           "detail": {
+                             "punishment": {
+                               "level": {
+                                 "strictest": [true]
+                               }
+                             }
+                           },
+                           "detail-type": ["cast:spell:unforgivable"]
                          }.to_json)
     end
   end

--- a/vars.tf
+++ b/vars.tf
@@ -75,8 +75,8 @@ variable "all_events" {
 }
 
 variable "filters" {
-  type        = map(list(string))
-  description = "Filters to apply against the event `detail`s. Must be a valid content filter (see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html)"
+  type        = map(any)
+  description = "Filters to apply against the event `detail`s. Must be a valid content filter (see [docs](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html))"
   default     = null
 }
 


### PR DESCRIPTION
Two fixes here:
1. Allow filters to be nested so long as they all meet the same type specifiers
2. Only create IAM roles for services that require it (this unfortunately is not specified in docs so has required testing via the console :rage:)