### PR TITLE
Fix IAM role assignment

### DIFF
--- a/.github/actions/ruby-tests/action.yml
+++ b/.github/actions/ruby-tests/action.yml
@@ -5,7 +5,7 @@ inputs:
   ruby_version:
     description: Version of Ruby to use.
     required: false
-    default: 3.2
+    default: 3.3
   working_dir:
     description: Directory containing Ruby code.
     required: true

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -28,7 +28,7 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
     steps:
       - uses: actions/checkout@v3
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.AWS_ROLE_NAME }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.3.7
+          terraform_version: 1.7.4
       - id: Init
         run: terraform init -no-color
       - id: Fmt
@@ -35,6 +35,6 @@ jobs:
           role-duration-seconds: 900
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.3.7
+          terraform_version: 1.7.4
           terraform_wrapper: false
       - uses: ./.github/actions/ruby-tests

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 3.2.1
-terraform 1.3.7
+ruby 3.3.0
+terraform 1.7.4

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 group :test do
+  gem 'racc'
   gem 'rspec'
   gem "rspec-terraform"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,7 @@ GEM
     partialruby (0.3.0)
       ruby2ruby (~> 2)
       ruby_parser (~> 3)
+    racc (1.7.3)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -71,9 +72,11 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
+  racc
   rspec
   rspec-terraform
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ No modules.
 | [aws_cloudwatch_event_connection.connection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_connection) | resource |
 | [aws_cloudwatch_event_rule.event_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.event_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
-| [aws_cloudwatch_event_target.event_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_event_target.event_target_with_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_event_target.event_target_without_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_iam_role.event_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.api_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.bus_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |

--- a/examples/event_api_targets/main.tf
+++ b/examples/event_api_targets/main.tf
@@ -32,7 +32,7 @@ module "named_event_mapping" {
 
       },
       slack-2 : {
-        endpoint : "https://hooks.slack.com/services/my/random/key"
+        endpoint : "https://hooks.slack.com/services/my/other/key"
         token : "xoxb-rando-tokenizer"
         template = <<EOF
 {

--- a/main.tf
+++ b/main.tf
@@ -32,12 +32,21 @@ resource "aws_cloudwatch_event_rule" "event_rule" {
   }, local.filters, local.not_accounts, local.accounts))
 }
 
-# handles the target mapping for lambdas, buses, and sqs (event_api is more complex)
-resource "aws_cloudwatch_event_target" "event_target" {
-  for_each = merge(var.targets.lambda, var.targets.bus, var.targets.sqs, var.targets.sfn)
+# handles the target mapping for targets that require an IAM role
+resource "aws_cloudwatch_event_target" "event_target_with_role" {
+  for_each = merge(var.targets.bus, var.targets.sfn)
 
   arn            = each.value
-  role_arn       = local.needs_iam ? aws_iam_role.event_role[0].arn : null
+  role_arn       = aws_iam_role.event_role[0].arn
+  rule           = aws_cloudwatch_event_rule.event_rule.name
+  event_bus_name = var.bus_name
+}
+
+# handles the target mapping for targets that prohibit using IAM roles
+resource "aws_cloudwatch_event_target" "event_target_without_role" {
+  for_each = merge(var.targets.lambda, var.targets.sqs)
+
+  arn            = each.value
   rule           = aws_cloudwatch_event_rule.event_rule.name
   event_bus_name = var.bus_name
 }

--- a/spec/mixed_mapping_spec.rb
+++ b/spec/mixed_mapping_spec.rb
@@ -48,6 +48,19 @@ RSpec.describe "mixed configuration tests" do
         expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: target)
                            .with_attribute_value(:name, "invoke-bus")
       end
+
+      it "adds role to resources that need it" do
+        # for the bus target
+        expect(@plan).not_to include_resource_creation(type: 'aws_cloudwatch_event_target', module_address: target)
+                           .with_attribute_value(:arn, 'arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic')
+                           .with_attribute_value(:role_arn, nil)
+      end
+
+      it "does not add role to resources which cannot accept it" do
+        # for the two lambda targets and one SQS target
+        expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_target', module_address: target)
+                           .with_attribute_value(:role_arn, nil).exactly(3).times
+      end
     end
 
     # Fix this


### PR DESCRIPTION
⚠️ need to apply this first: https://github.com/highwingio/concourse/pull/266 ⚠️

Certain targets cannot take IAM roles. Attempting to assign causes an error in the resource creation.

The easiest fix I can find is simply to split up the two resource types that can take roles and those that can't. The way we merge these two groups currently doesn't allow us to easily parse the target type in a single rule.

Specs are kinda weird on this one, but it does detect properly. Unfortunately because the target depends on the actual IAM role creation, we can't detect post-apply values, But it does validate if the role is set to something at all.