### PR TITLE
Fix Account Exclusion Rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.tfstate
 *.tfstate.*
 
+
 # Crash log files
 crash.log
 
@@ -27,3 +28,5 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+*.tfplan
+examples/**/.terraform.lock.hcl

--- a/examples/mixed_targets/main.tf
+++ b/examples/mixed_targets/main.tf
@@ -51,6 +51,11 @@ module "added-filters" {
     class = ["unforgivable"]
   }
 
+  # in the case both `allow_accounts` and `ignore_accounts are both specified
+  # the `allow_accounts` will take precedence as the more-restrictive filter
+  allow_accounts  = ["123456789012", "098765432109"]
+  ignore_accounts = ["2828282828282", "949494949494"]
+
   targets = {
     bus = {
       ministryOfMagic : "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic"
@@ -59,37 +64,6 @@ module "added-filters" {
       Duck : "arn:aws:lambda:us-east-1:123456789012:function:Duck",
       Dodge : "arn:aws:lambda:us-east-1:123456789012:function:Dodge",
       Weave : "arn:aws:lambda:us-east-1:123456789012:function:Weave",
-    }
-  }
-}
-
-module "account-filters-priority" {
-  source   = "../../"
-  bus_name = "the-knight-bus"
-
-  event_patterns = ["event.SpellCast"]
-
-  allow_accounts  = ["123456789012", "098765432109"]
-  ignore_accounts = ["2828282828282", "949494949494"] # this should be overwritten by the `allow_accounts` spec as more restrictive
-
-  targets = {
-    bus = {
-      ministryOfMagic : "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic"
-    }
-  }
-}
-
-module "account-filters" {
-  source   = "../../"
-  bus_name = "the-knight-bus"
-
-  event_patterns = ["event.SpellCast"]
-
-  ignore_accounts = ["2828282828282", "949494949494"]
-
-  targets = {
-    bus = {
-      ministryOfMagic : "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic"
     }
   }
 }

--- a/examples/mixed_targets/main.tf
+++ b/examples/mixed_targets/main.tf
@@ -51,9 +51,6 @@ module "added-filters" {
     class = ["unforgivable"]
   }
 
-  allow_accounts  = ["123456789012", "098765432109"]
-  ignore_accounts = ["2828282828282", "949494949494"] # this should be overwritten by the `allow_accounts` spec as more restrictive
-
   targets = {
     bus = {
       ministryOfMagic : "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic"
@@ -62,6 +59,37 @@ module "added-filters" {
       Duck : "arn:aws:lambda:us-east-1:123456789012:function:Duck",
       Dodge : "arn:aws:lambda:us-east-1:123456789012:function:Dodge",
       Weave : "arn:aws:lambda:us-east-1:123456789012:function:Weave",
+    }
+  }
+}
+
+module "account-filters-priority" {
+  source   = "../../"
+  bus_name = "the-knight-bus"
+
+  event_patterns = ["event.SpellCast"]
+
+  allow_accounts  = ["123456789012", "098765432109"]
+  ignore_accounts = ["2828282828282", "949494949494"] # this should be overwritten by the `allow_accounts` spec as more restrictive
+
+  targets = {
+    bus = {
+      ministryOfMagic : "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic"
+    }
+  }
+}
+
+module "account-filters" {
+  source   = "../../"
+  bus_name = "the-knight-bus"
+
+  event_patterns = ["event.SpellCast"]
+
+  ignore_accounts = ["2828282828282", "949494949494"]
+
+  targets = {
+    bus = {
+      ministryOfMagic : "arn:aws:events:us-east-1:123456789012:event-bus/ministryOfMagic"
     }
   }
 }

--- a/spec/mixed_mapping_spec.rb
+++ b/spec/mixed_mapping_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe "mixed configuration tests" do
       expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule', module_address: target)
                          .once
                          .with_attribute_value(:event_pattern, {
+                           "account": ["123456789012", "098765432109"],
                            "detail": {
                              "class": ["unforgivable"],
                              "type": ["curse"]
@@ -90,32 +91,6 @@ RSpec.describe "mixed configuration tests" do
       expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: target)
                          .with_attribute_value(:name, "invoke-bus")
                          .with_attribute_value(:policy, include("event-bus/ministryOfMagic"))
-    end
-  end
-
-  context "account-filters-priority" do
-    let(:target) { "module.account-filters-priority" }
-
-    it "prioritizes allowed accounts over ignored ones" do
-      expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule', module_address: target)
-                         .once
-                         .with_attribute_value(:event_pattern, {
-                           "account": %w[123456789012 098765432109],
-                           "detail-type": ["event.SpellCast"]
-                         }.to_json)
-    end
-  end
-
-  context "account-filters" do
-    let(:target) { "module.account-filters" }
-
-    it "formats excluded accounts correctly" do
-      expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule', module_address: target)
-                         .once
-                         .with_attribute_value(:event_pattern, {
-                           "account": [{ "anything-but": %w[2828282828282 949494949494]}],
-                           "detail-type": ["event.SpellCast"]
-                         }.to_json)
     end
   end
 
@@ -139,7 +114,7 @@ RSpec.describe "mixed configuration tests" do
       expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule', module_address: target)
                          .once
                          .with_attribute_value(:event_pattern, {
-                           "account": { "anything-but": ["2828282828282", "949494949494", current_account] },
+                           "account": [{ "anything-but": ["2828282828282", "949494949494", current_account] }],
                            "detail-type": ["speak:RoomOfRequirement"]
                          }.to_json)
     end
@@ -153,7 +128,7 @@ RSpec.describe "mixed configuration tests" do
       expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule', module_address: target)
                          .once
                          .with_attribute_value(:event_pattern, {
-                           "account": { "anything-but": [current_account] },
+                           "account": [{ "anything-but": [current_account] }],
                            "detail-type": ["speak:RoomOfRequirement"]
                          }.to_json)
     end

--- a/spec/mixed_mapping_spec.rb
+++ b/spec/mixed_mapping_spec.rb
@@ -76,7 +76,6 @@ RSpec.describe "mixed configuration tests" do
       expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule', module_address: target)
                          .once
                          .with_attribute_value(:event_pattern, {
-                           "account": %w[123456789012 098765432109],
                            "detail": {
                              "class": ["unforgivable"],
                              "type": ["curse"]
@@ -91,6 +90,32 @@ RSpec.describe "mixed configuration tests" do
       expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: target)
                          .with_attribute_value(:name, "invoke-bus")
                          .with_attribute_value(:policy, include("event-bus/ministryOfMagic"))
+    end
+  end
+
+  context "account-filters-priority" do
+    let(:target) { "module.account-filters-priority" }
+
+    it "prioritizes allowed accounts over ignored ones" do
+      expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule', module_address: target)
+                         .once
+                         .with_attribute_value(:event_pattern, {
+                           "account": %w[123456789012 098765432109],
+                           "detail-type": ["event.SpellCast"]
+                         }.to_json)
+    end
+  end
+
+  context "account-filters" do
+    let(:target) { "module.account-filters" }
+
+    it "formats excluded accounts correctly" do
+      expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_rule', module_address: target)
+                         .once
+                         .with_attribute_value(:event_pattern, {
+                           "account": [{ "anything-but": %w[2828282828282 949494949494]}],
+                           "detail-type": ["event.SpellCast"]
+                         }.to_json)
     end
   end
 

--- a/vars.tf
+++ b/vars.tf
@@ -109,5 +109,5 @@ locals {
   filters         = var.filters == null ? {} : { detail = var.filters }
   accounts        = length(var.allow_accounts) == 0 ? {} : { account = var.allow_accounts }
   ignore_accounts = var.exclude_self ? concat(var.ignore_accounts, [data.aws_caller_identity.self.account_id]) : var.ignore_accounts
-  not_accounts    = length(local.ignore_accounts) == 0 ? {} : { account = { "anything-but" : local.ignore_accounts } }
+  not_accounts    = length(local.ignore_accounts) == 0 ? {} : { account = [{ "anything-but" : local.ignore_accounts }] }
 }


### PR DESCRIPTION
There was a format issue around the `ignore_accounts` directive that misformatted the `anything-but` filter. This should fix it. Focused tests to capture this specific failure.

No changes to the external interface