### PR TITLE
Track target IDs explicitly

### DIFF
--- a/api_destination.tf
+++ b/api_destination.tf
@@ -27,6 +27,7 @@ resource "aws_cloudwatch_event_connection" "connection" {
 resource "aws_cloudwatch_event_target" "event_api" {
   for_each = var.targets.event_api
 
+  target_id      = each.key
   rule           = aws_cloudwatch_event_rule.event_rule.name
   arn            = aws_cloudwatch_event_api_destination.destination[each.key].arn
   role_arn       = aws_iam_role.event_role[0].arn

--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,7 @@ resource "aws_cloudwatch_event_target" "event_target_with_role" {
 resource "aws_cloudwatch_event_target" "event_target_without_role" {
   for_each = merge(var.targets.lambda, var.targets.sqs)
 
+  target_id      = each.key
   arn            = each.value
   rule           = aws_cloudwatch_event_rule.event_rule.name
   event_bus_name = var.bus_name


### PR DESCRIPTION
## Problem

We've recently seen certain targets get duplicated on certain rules. We assume this is because the IDs or ID-generation mechanism might change or get lost by some intermediate state/failure to apply/rollback and subsequent applies may attempt to re-create the rule without finding the previous one.

## Solve

Since we provide an explicit target key for every resource targeted, we can simply use that key as the `target_id` to ensure that we track properly for future applies.

No changes to external API. Unfortunately no additional tests b/c Terraform marks this as [a computed attribute](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/events/target.go#L488) which cannot be known until apply.