### PR TITLE
use endpoint for mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ No modules.
 | [aws_cloudwatch_event_target.event_target_without_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_iam_role.event_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.api_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.appysnc_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.appsync_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.bus_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.sfn_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_lambda_permission.permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_arn.gql_arns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/arn) | data source |
 | [aws_caller_identity.self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.api_event_invoke](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.appsync_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -74,7 +75,7 @@ No modules.
 | <a name="input_filters"></a> [filters](#input\_filters) | Filters to apply against the event `detail`s. Must be a valid content filter (see [docs](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html)) | `map(any)` | `null` | no |
 | <a name="input_ignore_accounts"></a> [ignore\_accounts](#input\_ignore\_accounts) | Ignored accounts. Will be overridden by `allow_accounts` if present. | `list(string)` | `[]` | no |
 | <a name="input_rule_name"></a> [rule\_name](#input\_rule\_name) | Unique name to give the event rule. If empty, will use the first event pattern. Required if using `all_events` | `string` | `null` | no |
-| <a name="input_targets"></a> [targets](#input\_targets) | Targets to route event to, mapped by target type | <pre>object({<br>    lambda = optional(set(string), [])<br>    bus    = optional(set(string), [])<br>    sqs    = optional(set(string), [])<br>    sfn    = optional(set(string), [])<br>    event_api = optional(map(object({<br>      endpoint : string,<br>      token : string,<br>      template_vars : optional(map(string), {}),<br>      template : string,<br>    })), {})<br>    appsync = optional(map(object({<br>      arn : string,<br>      operation : string<br>      passthrough : optional(bool, false),<br>      template_vars : optional(map(string), {}),<br>      template : optional(string),<br>      response_template : string<br>    })), {})<br>  })</pre> | n/a | yes |
+| <a name="input_targets"></a> [targets](#input\_targets) | Targets to route event to, mapped by target type | <pre>object({<br>    lambda = optional(set(string), [])<br>    bus    = optional(set(string), [])<br>    sqs    = optional(set(string), [])<br>    sfn    = optional(set(string), [])<br>    event_api = optional(map(object({<br>      endpoint : string,<br>      token : string,<br>      template_vars : optional(map(string), {}),<br>      template : string,<br>    })), {})<br>    appsync = optional(map(object({<br>      arn : string,<br>      http_url : string,<br>      operation : string<br>      passthrough : optional(bool, false),<br>      template_vars : optional(map(string), {}),<br>      template : optional(string),<br>      response_template : string<br>    })), {})<br>  })</pre> | n/a | yes |
 
 ## Outputs
 

--- a/appsync.tf
+++ b/appsync.tf
@@ -10,7 +10,7 @@ resource "aws_cloudwatch_event_target" "appsync" {
 
   target_id      = each.key
   rule           = aws_cloudwatch_event_rule.event_rule.name
-  arn            = each.value.arn
+  arn            = "arn:aws:appsync:us-east-1:${data.aws_arn.gql_arns[each.key].account}:endpoints/graphql-api/${regex("https://(\\w+)\\..+", each.value.http_url)[0]}"
   role_arn       = aws_iam_role.event_role[0].arn
   event_bus_name = var.bus_name
 

--- a/data.tf
+++ b/data.tf
@@ -1,1 +1,7 @@
 data "aws_caller_identity" "self" {}
+
+data "aws_arn" "gql_arns" {
+  for_each = var.targets.appsync
+
+  arn = each.value.arn
+}

--- a/examples/appsync_targets/main.tf
+++ b/examples/appsync_targets/main.tf
@@ -17,7 +17,7 @@ module "appsync_explicit" {
     appsync = {
       phoenix : {
         arn : "arn:aws:appsync:us-east-1:123456789012:apis/fawkes-phoenix"
-        http_url: "https://lotsofdigitsandchars.appsync-api.us-east-1.amazonaws.com/graphql"
+        http_url : "https://lotsofdigitsandchars.appsync-api.us-east-1.amazonaws.com/graphql"
 
         template : file("${path.module}/gql/request.json")
         template_vars = {
@@ -51,7 +51,7 @@ module "appsync_passthru" {
     appsync = {
       dobby : {
         arn : "arn:aws:appsync:us-east-1:123456789012:apis/house-elf-dobby"
-        http_url: "https://randomstringofcharacters.appsync-api.us-east-1.amazonaws.com/graphql"
+        http_url : "https://randomstringofcharacters.appsync-api.us-east-1.amazonaws.com/graphql"
 
         passthrough : true
         operation : "freeDobby"

--- a/examples/appsync_targets/main.tf
+++ b/examples/appsync_targets/main.tf
@@ -17,6 +17,7 @@ module "appsync_explicit" {
     appsync = {
       phoenix : {
         arn : "arn:aws:appsync:us-east-1:123456789012:apis/fawkes-phoenix"
+        http_url: "https://lotsofdigitsandchars.appsync-api.us-east-1.amazonaws.com/graphql"
 
         template : file("${path.module}/gql/request.json")
         template_vars = {
@@ -50,6 +51,7 @@ module "appsync_passthru" {
     appsync = {
       dobby : {
         arn : "arn:aws:appsync:us-east-1:123456789012:apis/house-elf-dobby"
+        http_url: "https://randomstringofcharacters.appsync-api.us-east-1.amazonaws.com/graphql"
 
         passthrough : true
         operation : "freeDobby"

--- a/spec/appsync_destination_spec.rb
+++ b/spec/appsync_destination_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "appsync targets" do
       it "specifies targets" do
         expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_target', module_address: 'module.appsync_explicit')
                            .with_attribute_value(:rule, "event.FightBasilisk")
+                           .with_attribute_value(:arn, "arn:aws:appsync:us-east-1:123456789012:endpoints/graphql-api/lotsofdigitsandchars")
                            .with_attribute_value([:input_transformer, 0, :input_paths], {
                              bring: "$.detail.bring",
                              healing: "$.detail.phoenix_tears",
@@ -35,6 +36,22 @@ RSpec.describe "appsync targets" do
                            .with_attribute_value([:appsync_target, 0, :graphql_operation],
                                                  "mutation CreateEmergency($input: CreateEmergencyInput!) { createEmergency(input: $input) {\n  message\n  status\n  eta\n}\n}")
       end
+
+      it "creates iam role for target" do
+        expect(@plan).to include_resource_creation(type: 'aws_iam_role', module_address: 'module.appsync_explicit').exactly(1).times
+        expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: 'module.appsync_explicit').exactly(1).times
+      end
+
+      it "permits only actions required" do
+        expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy')
+                           .with_attribute_value(:name, "invoke-appsync")
+                           .with_attribute_value(:policy, include("appsync:GraphQL"))
+                           .with_attribute_value(:policy, include("arn:aws:appsync:us-east-1:123456789012:apis/fawkes-phoenix"))
+
+        # can't currently validate this because the policy is generated based on the ARNs created by
+        # other resources
+        # .with_attribute_value(:policy, include("events:InvokeApiDestination"))
+      end
     end
 
     context "for passthrough mappings" do
@@ -45,6 +62,7 @@ RSpec.describe "appsync targets" do
       it "creates passthrough targets" do
         expect(@plan).to include_resource_creation(type: 'aws_cloudwatch_event_target', module_address: 'module.appsync_passthru')
                            .with_attribute_value(:rule, "event.SockGiven")
+                           .with_attribute_value(:arn, "arn:aws:appsync:us-east-1:123456789012:endpoints/graphql-api/randomstringofcharacters")
                            .with_attribute_value([:input_transformer, 0, :input_paths], {
                              input: "$.detail"
                            })
@@ -57,22 +75,21 @@ RSpec.describe "appsync targets" do
                                                  "mutation FreeDobby($input: FreeDobbyInput!) { freeDobby(input: $input) {\n  message\n  status\n  sockColor\n}\n}")
       end
     end
-  end
 
-  context "aws_iam_role" do
     it "creates iam role for target" do
-      expect(@plan).to include_resource_creation(type: 'aws_iam_role').exactly(2).times
-      expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy').exactly(2).times
+      expect(@plan).to include_resource_creation(type: 'aws_iam_role', module_address: 'module.appsync_passthru').exactly(1).times
+      expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy', module_address: 'module.appsync_passthru').exactly(1).times
     end
 
     it "permits only actions required" do
       expect(@plan).to include_resource_creation(type: 'aws_iam_role_policy')
                          .with_attribute_value(:name, "invoke-appsync")
+                         .with_attribute_value(:policy, include("appsync:GraphQL"))
+                         .with_attribute_value(:policy, include("arn:aws:appsync:us-east-1:123456789012:apis/house-elf-dobby"))
 
       # can't currently validate this because the policy is generated based on the ARNs created by
       # other resources
       # .with_attribute_value(:policy, include("events:InvokeApiDestination"))
-
     end
   end
 

--- a/vars.tf
+++ b/vars.tf
@@ -35,6 +35,7 @@ variable "targets" {
     })), {})
     appsync = optional(map(object({
       arn : string,
+      http_url : string,
       operation : string
       passthrough : optional(bool, false),
       template_vars : optional(map(string), {}),


### PR DESCRIPTION
### Are there any dependencies (software or human) that need to be addressed before this PR is merged?


### What ticket(s) or other PRs does this relate to?

Supporting the direct EB-to-AppSync mapping

### What was the problem or feature?

EB mappings to AppSync require the endpoints because, in the end, it's really an HTTP request, not just an "appsync call"

### What was the solution?

Ensure we map the endpoint arn but still permission the mutation based on the AppSync ARN

- [x] Security Impact has been considered (if yes please describe)
- [x] Network Impacts have been considered (if yes please describe)



### Where does this work fall on the Good - Fast spectrum?


### Any additional work needed as a result of merging this PR (deploy steps, other PRs, etc.)?
